### PR TITLE
Story chunks and PlayerTurnSubmit v1

### DIFF
--- a/server/src/domain/game/Character.ts
+++ b/server/src/domain/game/Character.ts
@@ -11,10 +11,12 @@ import { IRoomRepository } from '@/repositories/room/IRoomRepository';
 
 import { PlayerTurnSubmit } from './PlayerTurnSubmit';
 
+const MAX_PLAYER_SUBMIT_LENGTH = 280;
 export interface CharacterDetails {
     userID: string;
     nick: string;
     description: string;
+    playerTurnSubmit: PlayerTurnSubmit;
 }
 
 export class Character {
@@ -90,12 +92,24 @@ export class Character {
         return this.playerTurnSubmit;
     }
 
-    async setPlayerTurnSubmit(submit: PlayerTurnSubmit | undefined) {
-        await this.roomRepository.updateCharacter(this.id, {
-            ...this,
-            playerTurnSubmit: submit
-        });
+    async setPlayerTurnSubmit(submit: PlayerTurnSubmit) {
+        //is there a point of setting to undefined (submit undefined)?
+        if (submit && submit?.content.length > MAX_PLAYER_SUBMIT_LENGTH) {
+            throw new QuasmError(
+                QuasmComponent.CHARACTER,
+                400,
+                ErrorCode.MaxRoomName, //change this to a new error code
+                'Exceeded PlayerTurnSubmit max length'
+            );
+        }
 
-        this.playerTurnSubmit = submit;
+        const characterDetails: CharacterDetails = {
+            userID: this.id,
+            nick: this.nick,
+            description: this.description,
+            playerTurnSubmit: submit
+        };
+
+        return this.roomRepository.updateCharacter(this.id, characterDetails);
     }
 }

--- a/server/src/domain/game/Character.ts
+++ b/server/src/domain/game/Character.ts
@@ -94,7 +94,7 @@ export class Character {
 
     async setPlayerTurnSubmit(submit: PlayerTurnSubmit) {
         //is there a point of setting to undefined (submit undefined)?
-        if (submit && submit?.content.length > MAX_PLAYER_SUBMIT_LENGTH) {
+        if (submit.content.length > MAX_PLAYER_SUBMIT_LENGTH) {
             throw new QuasmError(
                 QuasmComponent.CHARACTER,
                 400,

--- a/server/src/domain/game/Room.test.ts
+++ b/server/src/domain/game/Room.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { randomUUID } from 'crypto';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -6,7 +8,7 @@ import { IRoomRepository } from '@/repositories/room/IRoomRepository';
 import { CharacterDetails } from './Character';
 // import { ChatMessage } from './ChatMessage';
 import { Room, RoomSettings } from './Room';
-// import { StoryChunk } from './StoryChunk';
+import { StoryChunk } from './StoryChunk';
 
 describe('Basic room actions', () => {
     const fakeRepo: IRoomRepository = {
@@ -29,7 +31,7 @@ describe('Basic room actions', () => {
         );
 
         const newName = 'Random name';
-        room.setName(newName);
+        void room.setName(newName);
         expect(room.getName()).toEqual(newName);
 
         const otherName = 'Another random name';
@@ -264,4 +266,42 @@ describe('Basic room actions', () => {
 
     //     expect(room.getStoryChunks()[0].imageUrl).toBeUndefined();
     // });
+});
+
+describe('Story Chunk tests', () => {
+    const fakeRepo: IRoomRepository = {
+        getRoomByID: vi.fn().mockReturnValue({}),
+        fetchRooms: vi.fn().mockReturnValue({}),
+        updateRoom: vi.fn().mockReturnValue({}),
+        createRoom: vi.fn().mockReturnValue({}),
+        deleteRoom: vi.fn().mockReturnValue({}),
+        addCharacter: vi.fn().mockReturnValue({}),
+        updateCharacter: vi.fn().mockReturnValue({}),
+        fetchStory: vi.fn().mockResolvedValue([]),
+        addStoryChunk: vi
+            .fn()
+            .mockImplementation((id, chunk) => Promise.resolve(chunk))
+    };
+
+    it('Can add and fetch StoryChunks', async () => {
+        const roomID = randomUUID();
+        const roomSettings = new RoomSettings('Example Room', 4);
+        const room = new Room(fakeRepo, roomID, roomSettings, []);
+
+        const newChunk = new StoryChunk(
+            -1,
+            'Story Title',
+            'Story content here',
+            'exampleURL',
+            new Date()
+        );
+        await room.addStoryChunk(newChunk);
+
+        const range = { offset: 5, count: 10 };
+        const retrievedChunks = await room.fetchStory(range);
+
+        expect(fakeRepo.addStoryChunk).toHaveBeenCalledTimes(1);
+        expect(fakeRepo.fetchStory).toHaveBeenCalledTimes(1);
+        expect(retrievedChunks).toEqual([newChunk]);
+    });
 });

--- a/server/src/repositories/room/IRoomRepository.ts
+++ b/server/src/repositories/room/IRoomRepository.ts
@@ -2,11 +2,17 @@ import { UUID } from 'crypto';
 
 import { Character, CharacterDetails } from '@/domain/game/Character';
 import { Room, RoomSettings } from '@/domain/game/Room';
+import { Range } from '@/domain/game/Room';
+import { StoryChunk } from '@/domain/game/StoryChunk';
 
 /**
  * Main repository that manages instances of Rooms and their persistence
  */
 export interface IRoomRepository {
+    fetchStoryChunks(
+        roomID: string,
+        range: Range
+    ): StoryChunk[] | PromiseLike<StoryChunk[]>;
     /**
      * Creates Room with single character (Game master) in it and returns created instance
      */
@@ -47,4 +53,14 @@ export interface IRoomRepository {
      * Just persists some character  attributes changes
      */
     updateCharacter(id: UUID, character: CharacterDetails): Promise<void>;
+
+    /**
+     * Adds StoryChunk to the specified Room
+     */
+    addStoryChunk(roomID: UUID, storyChunk: StoryChunk): Promise<StoryChunk>;
+
+    /**
+     * Returns the requested part of the story - the StoryChunks specified in Range
+     */
+    fetchStory(roomID: UUID, range: Range): Promise<StoryChunk[]>;
 }


### PR DESCRIPTION
StoryChunk and PlayerTurnSubmit logic mostly implemented
- methods: Room.fetchStory, Room.addStoryChunk, Character.setPlayerTurnSubmit, RoomRepositoryPostgres.addStoryChunk, RoomRepositoryPostgres.fetchStory
- unit tests: Room - updated, RoomRepositoryPostgres - in the making
- bugs: RoomRepo.addStoryChunk - initializing chunkID, RoomRepo.fetchStory - checking IDs in between bounds 
- setup: no new ErrorCodes in /common for addStoryChunk, setPlayerTurnSubmit; max values hardcoded in the specific files